### PR TITLE
[feat] 버튼 컴포넌트 구현

### DIFF
--- a/src/shared/styles/theme.ts
+++ b/src/shared/styles/theme.ts
@@ -21,6 +21,31 @@ export const theme = {
     'gray-900': '#0f1014',
   },
 
+  GRADIENT: {
+    hologram: `conic-gradient(
+      from 0deg,
+      #ffffff 0deg,
+      #c2fff4 68deg,
+      #f8fccc 100deg,
+      #c5f3eb 180deg,
+      #ffe2fe 254deg,
+      #c0f9ef 275deg,
+      #fffbe9 300deg,
+      #ffffff 360deg
+    )`,
+    gradient1: `linear-gradient(
+      to right,
+      #c0f5e5 0%,
+      #eaf1e6 77%,
+      #f0f1ce 100%
+    )`,
+    gradient2: `linear-gradient(
+      to right,
+      #8ef5e2 0%,
+      #d8f5fe 100%
+    )`,
+  },
+
   OPACITY: {
     scrim: 'rgba(15, 16, 20, 0.6)',
   },

--- a/src/shared/ui/Button.tsx
+++ b/src/shared/ui/Button.tsx
@@ -1,73 +1,59 @@
+import type { ReactNode, MouseEventHandler } from 'react'
+
 import styled, { css } from 'styled-components'
 
 type ButtonSize = 'L' | 'M' | 'S'
 type ButtonState = 'primary' | 'secondary' | 'disabled'
 
 interface ButtonProps {
-  children: React.ReactNode
+  children: ReactNode
   size: ButtonSize
   state: ButtonState
-  onClick?: () => void
+  onClick?: MouseEventHandler<HTMLButtonElement>
 }
 
-const getSizeStyles = (size: ButtonSize) => {
-  switch (size) {
-    case 'L':
-      return css`
-        min-width: 335px;
-        height: 46px;
-        border-radius: 10px;
-        ${({ theme }) => theme.FONT['body1-normal']}
-      `
-    case 'M':
-      return css`
-        min-width: 76px;
-        height: 42px;
-        border-radius: 10px;
-        ${({ theme }) => theme.FONT['body2-normal']}
-      `
-    case 'S':
-      return css`
-        padding: 5px 8px;
-        min-width: 51px;
-        height: 26px;
-        border-radius: 99px;
-        ${({ theme }) => theme.FONT.caption1}
-      `
-    default:
-      return css`
-        min-width: 76px;
-        height: 42px;
-        border-radius: 10px;
-        ${({ theme }) => theme.FONT['body2-normal']}
-      `
-  }
+const BUTTON_STYLES = {
+  L: { minWidth: '335px', height: '46px', borderRadius: '10px' },
+  M: { minWidth: '76px', height: '42px', borderRadius: '10px' },
+  S: { minWidth: '51px', height: '26px', borderRadius: '99px' },
+} as const
+
+const sizeStyles: Record<ButtonSize, ReturnType<typeof css>> = {
+  L: css`
+    min-width: ${BUTTON_STYLES.L.minWidth};
+    height: ${BUTTON_STYLES.L.height};
+    border-radius: ${BUTTON_STYLES.L.borderRadius};
+    ${({ theme }) => theme.FONT['body1-normal']}
+  `,
+  M: css`
+    min-width: ${BUTTON_STYLES.M.minWidth};
+    height: ${BUTTON_STYLES.M.height};
+    border-radius: ${BUTTON_STYLES.M.borderRadius};
+    ${({ theme }) => theme.FONT['body2-normal']}
+  `,
+  S: css`
+    padding: 5px 8px;
+    min-width: ${BUTTON_STYLES.S.minWidth};
+    height: ${BUTTON_STYLES.S.height};
+    border-radius: ${BUTTON_STYLES.S.borderRadius};
+    ${({ theme }) => theme.FONT.caption1}
+  `,
 }
 
-const getStateStyles = (state: ButtonState) => {
-  switch (state) {
-    case 'primary':
-      return css`
-        background: ${({ theme }) => theme.COLOR['primary-normal']};
-        color: ${({ theme }) => theme.COLOR['gray-900']};
-      `
-    case 'secondary':
-      return css`
-        background: ${({ theme }) => theme.COLOR['gray-600']};
-        color: ${({ theme }) => theme.COLOR['primary-normal']};
-      `
-    case 'disabled':
-      return css`
-        background: ${({ theme }) => theme.COLOR['gray-600']};
-        color: ${({ theme }) => theme.COLOR['gray-400']};
-        cursor: not-allowed;
-      `
-    default:
-      return css`
-        background: ${({ theme }) => theme.COLOR['gray-600']};
-        color: ${({ theme }) => theme.COLOR['gray-400']};
-      `
-  }
+const stateStyles: Record<ButtonState, ReturnType<typeof css>> = {
+  primary: css`
+    background: ${({ theme }) => theme.COLOR['primary-normal']};
+    color: ${({ theme }) => theme.COLOR['gray-900']};
+  `,
+  secondary: css`
+    background: ${({ theme }) => theme.COLOR['gray-600']};
+    color: ${({ theme }) => theme.COLOR['primary-normal']};
+  `,
+  disabled: css`
+    background: ${({ theme }) => theme.COLOR['gray-600']};
+    color: ${({ theme }) => theme.COLOR['gray-400']};
+    cursor: not-allowed;
+  `,
 }
 
 const Button = ({ children, size = 'M', state = 'primary', onClick }: ButtonProps) => {
@@ -93,6 +79,6 @@ const StyledButton = styled.button<{
   display: flex;
   align-items: center;
   justify-content: center;
-  ${({ size }) => getSizeStyles(size)}
-  ${({ state }) => getStateStyles(state)}
+  ${({ size }) => sizeStyles[size]}
+  ${({ state }) => stateStyles[state]}
 `

--- a/src/shared/ui/Button.tsx
+++ b/src/shared/ui/Button.tsx
@@ -1,0 +1,97 @@
+import styled, { css } from 'styled-components'
+
+type ButtonSize = 'L' | 'M' | 'S'
+type ButtonState = 'primary' | 'secondary' | 'disabled'
+
+interface ButtonProps {
+  children: React.ReactNode
+  size: ButtonSize
+  state: ButtonState
+  onClick?: () => void
+}
+
+const getSizeStyles = (size: ButtonSize) => {
+  switch (size) {
+    case 'L':
+      return css`
+        width: 335px;
+        height: 46px;
+        border-radius: 10px;
+        ${({ theme }) => theme.FONT['body1-normal']}
+      `
+    case 'M':
+      return css`
+        width: 76px;
+        height: 42px;
+        border-radius: 10px;
+        ${({ theme }) => theme.FONT['body2-normal']}
+      `
+    case 'S':
+      return css`
+        width: 51px;
+        height: 26px;
+        border-radius: 99px;
+        ${({ theme }) => theme.FONT.caption1}
+      `
+    default:
+      return css`
+        width: 76px;
+        height: 42px;
+        border-radius: 10px;
+        ${({ theme }) => theme.FONT['body2-normal']}
+      `
+  }
+}
+
+const getStateStyles = (state: ButtonState) => {
+  switch (state) {
+    case 'primary':
+      return css`
+        background: ${({ theme }) => theme.COLOR['primary-normal']};
+        color: ${({ theme }) => theme.COLOR['gray-900']};
+      `
+    case 'secondary':
+      return css`
+        background: ${({ theme }) => theme.COLOR['gray-600']};
+        color: ${({ theme }) => theme.COLOR['primary-normal']};
+      `
+    case 'disabled':
+      return css`
+        background: ${({ theme }) => theme.COLOR['gray-600']};
+        color: ${({ theme }) => theme.COLOR['gray-400']};
+        cursor: not-allowed;
+      `
+    default:
+      return css`
+        background: ${({ theme }) => theme.COLOR['gray-600']};
+        color: ${({ theme }) => theme.COLOR['gray-400']};
+      `
+  }
+}
+
+const Button: React.FC<ButtonProps> = ({ children, size = 'M', state = 'primary', onClick }) => {
+  return (
+    <StyledButton
+      type="button"
+      size={size}
+      state={state}
+      onClick={onClick}
+      disabled={state === 'disabled'}
+    >
+      {children}
+    </StyledButton>
+  )
+}
+
+export default Button
+
+const StyledButton = styled.button<{
+  size: ButtonSize
+  state: ButtonState
+}>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  ${({ size }) => getSizeStyles(size)}
+  ${({ state }) => getStateStyles(state)}
+`

--- a/src/shared/ui/Button.tsx
+++ b/src/shared/ui/Button.tsx
@@ -14,28 +14,29 @@ const getSizeStyles = (size: ButtonSize) => {
   switch (size) {
     case 'L':
       return css`
-        width: 335px;
+        min-width: 335px;
         height: 46px;
         border-radius: 10px;
         ${({ theme }) => theme.FONT['body1-normal']}
       `
     case 'M':
       return css`
-        width: 76px;
+        min-width: 76px;
         height: 42px;
         border-radius: 10px;
         ${({ theme }) => theme.FONT['body2-normal']}
       `
     case 'S':
       return css`
-        width: 51px;
+        padding: 5px 8px;
+        min-width: 51px;
         height: 26px;
         border-radius: 99px;
         ${({ theme }) => theme.FONT.caption1}
       `
     default:
       return css`
-        width: 76px;
+        min-width: 76px;
         height: 42px;
         border-radius: 10px;
         ${({ theme }) => theme.FONT['body2-normal']}

--- a/src/shared/ui/Button.tsx
+++ b/src/shared/ui/Button.tsx
@@ -70,7 +70,7 @@ const getStateStyles = (state: ButtonState) => {
   }
 }
 
-const Button: React.FC<ButtonProps> = ({ children, size = 'M', state = 'primary', onClick }) => {
+const Button = ({ children, size = 'M', state = 'primary', onClick }: ButtonProps) => {
   return (
     <StyledButton
       type="button"

--- a/src/shared/ui/Button.tsx
+++ b/src/shared/ui/Button.tsx
@@ -56,7 +56,7 @@ const stateStyles: Record<ButtonState, ReturnType<typeof css>> = {
   `,
 }
 
-const Button = ({ children, size = 'M', state = 'primary', onClick }: ButtonProps) => {
+const Button = ({ children, size, state, onClick }: ButtonProps) => {
   return (
     <StyledButton
       type="button"

--- a/src/stories/Button.stories.ts
+++ b/src/stories/Button.stories.ts
@@ -1,0 +1,84 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import Button from '@/shared/ui/Button'
+
+const meta = {
+  title: 'Shared/Button',
+  component: Button,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      control: { type: 'select' },
+      options: ['L', 'M', 'S'],
+    },
+    state: {
+      control: { type: 'select' },
+      options: ['primary', 'secondary', 'disabled'],
+    },
+    onClick: { action: 'clicked' },
+  },
+} satisfies Meta<typeof Button>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    children: 'Button',
+    size: 'M',
+    state: 'primary',
+  },
+}
+
+export const SizeLarge: Story = {
+  args: {
+    children: 'Large',
+    size: 'L',
+    state: 'primary',
+  },
+}
+
+export const SizeMedium: Story = {
+  args: {
+    children: 'Medium',
+    size: 'M',
+    state: 'primary',
+  },
+}
+
+export const SizeSmall: Story = {
+  args: {
+    children: 'Small',
+    size: 'S',
+    state: 'primary',
+  },
+}
+
+export const StatePrimary: Story = {
+  args: {
+    children: 'Primary',
+    size: 'M',
+    state: 'primary',
+    onClick: () => alert('Primary clicked'),
+  },
+}
+
+export const StateSecondary: Story = {
+  args: {
+    children: 'Secondary',
+    size: 'M',
+    state: 'secondary',
+    onClick: () => alert('Secondary clicked'),
+  },
+}
+
+export const StateDisabled: Story = {
+  args: {
+    children: 'Disabled',
+    size: 'M',
+    state: 'disabled',
+  },
+}


### PR DESCRIPTION
<!-- ⚠️ PR 제목은 관련 이슈번호의 제목과 동일하게 설정해주세요! ⚠️ -->

## 🛰️ 관련 이슈

<!--
  - 하단의 issue_number를 관련 이슈 번호(들)로 설정해주세요.
  - 여러 개의 이슈가 연관되어 있을 경우 엔터로 구분해주세요.
-->

- close #17 

<br />

## ✨ 주요 변경 사항

<!--
  - ### 1️⃣, ### 2️⃣, ### 3️⃣, ### 4️⃣ 등으로 구분해주세요.
  - 스크린샷은 필요 시 주요 변경사항에 함께 첨부해주시면 좋습니다.
-->

### 1️⃣ theme.ts에 gradient 추가

<table>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/b402db43-8112-49f8-ba4a-7e15550242c9" alt="figma" />
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/1870a4c6-42e1-441a-b223-321a3828b05a" alt="theme" />
    </td>
  </tr>
  <tr>
    <th>figma</th>
    <th>theme</th>
  </tr>
</table>

- figma에 gradient도 설정되어있길래 일단 같이 넣어두었습니다!

<br />

### 2️⃣ Button 컴포넌트 추가

- Button 컴포넌트를 구현했습니다.

<br />

## 🔍 테스트 방법 / 체크리스트

<!--
  - 리뷰어의 테스트가 필요할 경우 아래 중 하나를 참고해 작성해주세요.
  - 작성하지 않아도 될 경우 이 항목을 '- 없음' 으로 작성해주세요.
-->

- 없음

<br />

## 🗯️ PR 포인트

<!--
  - 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
  - 작성하지 않아도 될 경우 이 항목을 '- 없음' 으로 작성해주세요.
-->

- button의 속성은 type, onClick, disabled만 설정해두었습니다.
- type은 button, 퍼블 단계라 onClick은 필수값이 아닐 수 있도록 설정해두었으며<br />disabled는 state의 props가 disabled인 경우 함께 설정됩니다.
- children으로 아이콘이 들어오는 경우 width로만 설정 시 디자인과 사이즈가 맞지 않는 경우가 있어,<br />width를 min-width로 설정해두었습니다.

    ```tsx
    // 예시: size가 s고 children으로 icon이 들어오는 케이스
    import { Play } from '@/assets/icons'
    import Button from '@/shared/ui/Button'

    <Button size="S" state="primary">
      <Play />
      <span style={{ marginLeft: '2px' }}>PLAY</span>
    </Button>
    ````

    <table>
      <tr>
        <td>
          <img src="https://github.com/user-attachments/assets/8379f6f0-2866-4d31-9f4c-d27ec5d54259" alt="figma" />
        </td>
        <td>
          <img src="https://github.com/user-attachments/assets/e363c2ea-8e30-459f-83c2-d08004ddad05" alt="theme" />
        </td>
      </tr>
      <tr>
        <th align="center">figma</th>
        <th align="center">develop</th>
      </tr>
    </table>

<br />

## 🚀 알게된 점

<!--
  - 코드를 작성 하면서 어떤 고민점이 있었는지, 또는 배우게된 것이 있다면 작성해주세요.
  - 작성하지 않아도 될 경우 이 항목을 '- 없음' 으로 작성해주세요.
-->

- 코드 구현 시 React.FC를 사용해 자동으로 children 타입이 포함되도록 제작하였으나, 아래와 같은 이유로 사용이 권장되지 않는다고 하여 제거함

  1. **children** 프로퍼티의 암시적 포함: <br />자식 요소를 받지 않는 경우가 있을 수 있는데, children 프로퍼티가 암시적으로 포함되어 TypeScript가 의도치 않은 버그를 발생시킬 수 있음
  
  2. **제네릭 사용 시 복잡성 증가**: <br />복잡한 타입 확장이 필요할 때 직관적으로 사용하기 어려워 타입 추론 문제 발생<br />_[참고] 제네릭: 타입을 자유롭게 바꿀 수 있는 '타입 변수' 개념으로, TypeScript에서 재사용 코드를 만들 때 유용_
  
  3. **Facebook (React팀) 공식 템플릿에서도 React.FC가 제거**되었고, TypeScript와 React 최신 버전에서는 명시적 타입 선언 방식 사용을 강력히 권장함

- 즉, 예전에는 React.FC를 함수형 컴포넌트를 편하게 선언하기 위해 주로 사용했으나 타입 안정성 부족과 확장성 등의 문제로 지금은 거의 사용하지 않음

<br />

## 📖 참고 자료 (선택)

<!--
  - 작업하면서 참고했던 문서가 있다면 공유해주세요.
  - 작성하지 않아도 될 경우 이 항목을 '- 없음' 으로 작성해주세요.
-->

- [facebook/create-react-app Github PR #8177: Remove React.FC from Typescript template](https://github.com/facebook/create-react-app/pull/8177)
- [React TypeScript Cheatsheet: Why is React.FC not needed?](https://react-typescript-cheatsheet.netlify.app/docs/basic/getting-started/function_components)
- [Backstage: Avoid React.FC and React.SFC](https://backstage.io/docs/architecture-decisions/adrs-adr006)
- [Velog: React.FC 사용을 지양해야 하는 이유](https://velog.io/@geonhwi1014/ReactReact.FC-%EC%82%AC%EC%9A%A9-%EC%A7%80%EC%96%91%ED%95%B4%EC%95%BC%ED%95%98%EB%8A%94-%EC%9D%B4%EC%9C%A0)
- [Inflearn: 타입스크립트로 리액트 프로젝트를 하면서 React.FC에 질문이 있습니다.](https://www.inflearn.com/community/questions/1113860)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 버튼 컴포넌트를 추가했습니다. 크기(L/M/S)와 상태(기본/보조/비활성)를 지원하며 클릭 핸들러와 비활성화 시 동작(비활성 커서 등)이 포함됩니다.
  - 테마에 그라데이션 토큰 3종(홀로그램, gradient1, gradient2)을 추가했습니다. 배경 및 장식 효과에 사용 가능합니다.
- 문서
  - 버튼 컴포넌트용 스토리북 스토리를 추가했습니다(기본, 크기별, 상태별 변형 및 상호작용).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->