### PR TITLE
[feat] 둘러보기 UX 개선사항 반영

### DIFF
--- a/src/shared/ui/Link.tsx
+++ b/src/shared/ui/Link.tsx
@@ -6,11 +6,12 @@ import type { Track } from '@/entities/playlist'
 interface LinkProps {
   variant?: 'large' | 'small'
   data: Track
+  onClick?: () => void
 }
 
-const Link = ({ variant = 'large', data }: LinkProps) => {
+const Link = ({ variant = 'large', data, onClick }: LinkProps) => {
   return (
-    <LinkBox $variant={variant}>
+    <LinkBox $variant={variant} onClick={onClick}>
       <Thumbnail $thumbnail={data.youtubeThumbnail ?? undefined} $variant={variant}>
         {!data.youtubeThumbnail && (
           <Gallery width={variant === 'large' ? 24 : 20} height={variant === 'large' ? 24 : 20} />

--- a/src/widgets/playlist/PlaylistInfo.tsx
+++ b/src/widgets/playlist/PlaylistInfo.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from 'react-router-dom'
 
 import styled from 'styled-components'
 
+import { usePlaylist } from '@/app/providers/PlayerProvider'
 import { Cancel } from '@/assets/icons'
 import type { PlaylistDetailResponse } from '@/entities/playlist'
 import { getGenreLabel } from '@/shared/lib'
@@ -17,6 +18,13 @@ interface PlaylistInfoProps {
 
 const PlaylistInfo = ({ playlistData, isLoading, isError }: PlaylistInfoProps) => {
   const navigate = useNavigate()
+  const { setPlaylist, currentPlaylist } = usePlaylist()
+
+  const handleClickTrack = (trackIndex: number) => {
+    if (!currentPlaylist) return
+    navigate(-1)
+    setPlaylist(currentPlaylist, trackIndex, 0)
+  }
 
   if (isError || !playlistData) {
     return (
@@ -50,7 +58,12 @@ const PlaylistInfo = ({ playlistData, isLoading, isError }: PlaylistInfoProps) =
         <TrackInfo>
           {playlistData.songs &&
             playlistData.songs.map((track, index) => (
-              <Link key={index} data={track} variant="large" />
+              <Link
+                key={index}
+                data={track}
+                variant="large"
+                onClick={() => handleClickTrack(index)}
+              />
             ))}
         </TrackInfo>
       </Content>

--- a/src/widgets/playlist/PlaylistLayout.tsx
+++ b/src/widgets/playlist/PlaylistLayout.tsx
@@ -80,7 +80,7 @@ const PlaylistLayout = ({
         )}
       </Container>
       <Wrapper>
-        <CdWrapper>
+        <CdWrapper $isPlaying={isPlaying}>
           {isMobile && (
             <VolumeButton playerRef={playerRef} isMuted={isMuted} setIsMuted={setIsMuted} />
           )}
@@ -130,6 +130,18 @@ const Container = styled.div`
   justify-content: space-between;
 `
 
-const CdWrapper = styled.div`
+const CdWrapper = styled.div<{ $isPlaying: boolean }>`
   position: relative;
+  animation: spin 40s linear infinite;
+  animation-play-state: ${(props) => (props.$isPlaying ? 'running' : 'paused')};
+  transform-origin: center;
+
+  @keyframes spin {
+    0% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
+  }
 `

--- a/src/widgets/playlist/YoutubePlayer.tsx
+++ b/src/widgets/playlist/YoutubePlayer.tsx
@@ -1,7 +1,7 @@
+import { useRef, useEffect } from 'react'
 import YouTube from 'react-youtube'
-import type { YouTubeProps, YouTubeEvent, YouTubePlayer } from 'react-youtube' //
+import type { YouTubeProps, YouTubeEvent, YouTubePlayer } from 'react-youtube'
 
-import { useDevice } from '@/shared/lib/useDevice'
 
 interface YoutubePlayerProps {
   videoId: string
@@ -10,23 +10,38 @@ interface YoutubePlayerProps {
 }
 
 function YoutubePlayer({ videoId, onReady, onStateChange }: YoutubePlayerProps) {
-  const deviceType = useDevice()
-  const isMobile = deviceType === 'mobile'
+  const playerRef = useRef<YouTubePlayer | null>(null)
+  const isFirstLoad = useRef(true)
 
   const playerOpts: YouTubeProps['opts'] = {
     playerVars: {
       autoplay: 1,
-      mute: isMobile ? 1 : 0,
+      mute: 0,
       playsinline: 1, // 모바일 인라인 재생
     },
   }
+
+  useEffect(() => {
+    if (!isFirstLoad.current && playerRef.current && videoId) {
+      // 첫 로딩 제외하고 loadVideoById 호출
+      try {
+        playerRef.current.loadVideoById(videoId)
+      } catch (e) {
+        console.error('loadVideoById 실패', e)
+      }
+    }
+    isFirstLoad.current = false
+  }, [videoId])
 
   return (
     <div style={{ width: 0, height: 0, overflow: 'hidden', position: 'absolute' }}>
       <YouTube
         videoId={videoId}
         opts={playerOpts}
-        onReady={onReady}
+        onReady={(e) => {
+          playerRef.current = e.target
+          onReady(e)
+        }}
         onStateChange={onStateChange}
       />
     </div>


### PR DESCRIPTION
<!-- ⚠️ PR 제목은 관련 이슈번호의 제목과 동일하게 설정해주세요! ⚠️ -->

## 🛰️ 관련 이슈

<!--
  - 하단의 issue_number를 관련 이슈 번호(들)로 설정해주세요.
  - 여러 개의 이슈가 연관되어 있을 경우 엔터로 구분해주세요.
-->

- close #107 

<br />

## ✨ 주요 변경 사항

<!--
  - ### 1️⃣, ### 2️⃣, ### 3️⃣, ### 4️⃣ 등으로 구분해주세요.
  - 스크린샷은 필요 시 주요 변경사항에 함께 첨부해주시면 좋습니다.
-->

11차 회의에서 결정된 플레이어 사용성 개선 사항을 반영했습니다.
- 플레이어 재생 중일 때 CD 회전 애니메이션 추가
- 플레이리스트 상세 → 특정 곡 링크 클릭 시 해당 인덱스부터 재생되도록 수정
- 모바일 최초 unmute 이후 상태 유지되도록 수정

<br />

## 🔍 테스트 방법 / 체크리스트

<!--
  - 리뷰어의 테스트가 필요할 경우 아래 중 하나를 참고해 작성해주세요.
  - 작성하지 않아도 될 경우 이 항목을 '- 없음' 으로 작성해주세요.
-->

- [ ] 모바일 환경에서 최초 unmute 이후 음소거 상태가 유지되는지 확인

<br />

## 🗯️ PR 포인트

<!--
  - 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
  - 작성하지 않아도 될 경우 이 항목을 '- 없음' 으로 작성해주세요.
-->

- unmute 상태 유지되도록 새 videoId가 들어오면 loadVideoById로 곡을 바꾸고 기존 상태를 유지하도록 수정하였습니다.

<br />

## 🚀 알게된 점

<!--
  - 코드를 작성 하면서 어떤 고민점이 있었는지, 또는 배우게된 것이 있다면 작성해주세요.
  - 작성하지 않아도 될 경우 이 항목을 '- 없음' 으로 작성해주세요.
-->

- `animation-play-state` 속성
    - CSS 애니메이션을 멈추거나 이어서 실행할 수 있음.
        - running : 애니메이션 실행
        - paused : 애니메이션 멈춤 (멈춘 시점에서 정지 → 다시 running 하면 이어서 진행됨)

<br />

## 📖 참고 자료 (선택)

<!--
  - 작업하면서 참고했던 문서가 있다면 공유해주세요.
  - 작성하지 않아도 될 경우 이 항목을 '- 없음' 으로 작성해주세요.
-->

-
