### PR TITLE
[fix] 배포 관련 커밋에서 이슈 번호 자동 추가 제외 처리

### DIFF
--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -8,11 +8,18 @@ COMMIT_MSG_FILE=$1
 # 커밋 메시지 읽기
 COMMIT_MSG=$(cat "$COMMIT_MSG_FILE")
 
+# deploy로 시작하면 이슈 번호 추가하지 않음
+if echo "$COMMIT_MSG" | grep -iq "^deploy:"; then
+  echo "배포 커밋이므로 이슈 번호를 추가하지 않습니다."
+  exit 0
+fi
+
 # 이미 issue 번호가 있는지 확인
 if echo "$COMMIT_MSG" | grep -q "#[0-9]*"; then
   echo "커밋메세지에 이슈 번호가 포함되어 있습니다."
   exit 0
 fi
+
 
 # issue 번호가 없고 브랜치에서 추출한 번호가 있으면 추가
 if [ -n "$ISSUE_NUMBER" ]; then

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -13,6 +13,7 @@ export default {
         'docs', // README, 주석, 문서 파일 수정
         'revert', // 이전 커밋으로 복구
         'test', // 테스트 코드 추가 및 수정
+        'deploy', // 배포
       ],
     ],
     'subject-case': [0], // 제목 대소문자 규칙 비활성화 (한국어 지원)


### PR DESCRIPTION
<!-- ⚠️ PR 제목은 관련 이슈번호의 제목과 동일하게 설정해주세요! ⚠️ -->

## 🛰️ 관련 이슈

<!--
  - 하단의 issue_number를 관련 이슈 번호(들)로 설정해주세요.
  - 여러 개의 이슈가 연관되어 있을 경우 엔터로 구분해주세요.
-->

- close #153 

<br />

## ✨ 주요 변경 사항

<!--
  - ### 1️⃣, ### 2️⃣, ### 3️⃣, ### 4️⃣ 등으로 구분해주세요.
  - 스크린샷은 필요 시 주요 변경사항에 함께 첨부해주시면 좋습니다.
-->

배포 관련 커밋에서 이슈 번호 자동 추가 제외 처리

<br />

## 🔍 테스트 방법 / 체크리스트

<!--
  - 리뷰어의 테스트가 필요할 경우 아래 중 하나를 참고해 작성해주세요.
  - 작성하지 않아도 될 경우 이 항목을 '- 없음' 으로 작성해주세요.
-->

- 없음

<br />

## 🗯️ PR 포인트

<!--
  - 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
  - 작성하지 않아도 될 경우 이 항목을 '- 없음' 으로 작성해주세요.
-->

dev > prod 배포 시, develop 브랜치에서 package.json 버전 업데이트 후 PR을 올리기로 했었는데
이때 커밋 메시지는 `deploy: v1.n.n` 형식을 사용하면 될 것 같아서,
해당 형식에 대응할 수 있도록 commitlint 설정에 `deploy` enum type을 추가하고 deploy로 시작하는 커밋은 이슈번호를 추가하지 않도록 수정했습니다 (혹시 no-issue가 붙어서 나오는 기존 설정이 더 나을까요 ..??)


++
요거까지 수정하고 v1.0.1 올리갰습니다 !!


<br />

## 🚀 알게된 점

<!--
  - 코드를 작성 하면서 어떤 고민점이 있었는지, 또는 배우게된 것이 있다면 작성해주세요.
  - 작성하지 않아도 될 경우 이 항목을 '- 없음' 으로 작성해주세요.
-->

-

<br />

## 📖 참고 자료 (선택)

<!--
  - 작업하면서 참고했던 문서가 있다면 공유해주세요.
  - 작성하지 않아도 될 경우 이 항목을 '- 없음' 으로 작성해주세요.
-->

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 커밋 타입에 "deploy" 추가로 배포 관련 커밋 지원 확대
  * "deploy:" 접두사를 가진 커밋 메시지 처리 로직 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->