### PR TITLE
[fix] 백엔드 API 운영 배포 버전에 맞춰 Response Key 수정

### DIFF
--- a/src/features/auth/api/auth.ts
+++ b/src/features/auth/api/auth.ts
@@ -1,4 +1,4 @@
-import type { LoginPayload, LoginResponse, UserInfo } from '@/features/auth/types/auth'
+import type { LoginPayload, LoginResponse, ChatUserInfo } from '@/features/auth/types/auth'
 import { api } from '@/shared/api/httpClient'
 
 // 회원 로그인 (카카오)
@@ -18,5 +18,5 @@ export const deleteAccount = () => {
 
 // 채팅 내 이름/아이디 확인
 export const getUserInfo = () => {
-  return api.get<UserInfo>('/chat/user')
+  return api.get<ChatUserInfo>('/chat/user')
 }

--- a/src/features/auth/store/authStore.ts
+++ b/src/features/auth/store/authStore.ts
@@ -7,15 +7,15 @@ import type { ProfileResponse } from '@/features/profile/types/profile'
 export const useAuthStore = create<AuthState>()(
   persist(
     (set) => ({
-      userInfo: { userId: '', username: '', userProfileImageUrl: null },
+      userInfo: { userId: '', nickname: '', profileUrl: null },
       isLogin: false,
       accessToken: '',
 
       setLogin: (response) => {
         sessionStorage.removeItem('anonymous_token')
-        const { userId, username, userProfileImageUrl, jwtAccessToken } = response
+        const { userId, nickname, profileUrl, jwtAccessToken } = response
         set({
-          userInfo: { userId, username, userProfileImageUrl },
+          userInfo: { userId, nickname, profileUrl },
           accessToken: jwtAccessToken,
           isLogin: true,
         })
@@ -24,7 +24,7 @@ export const useAuthStore = create<AuthState>()(
       setLogout: () => {
         localStorage.removeItem('deulak_auth')
         set({
-          userInfo: { userId: '', username: '', userProfileImageUrl: null },
+          userInfo: { userId: '', nickname: '', profileUrl: null },
           accessToken: '',
           isLogin: false,
         })
@@ -34,8 +34,8 @@ export const useAuthStore = create<AuthState>()(
         set({
           userInfo: {
             userId: payload.userId,
-            username: payload.nickname,
-            userProfileImageUrl: payload.profileImageUrl,
+            nickname: payload.nickname,
+            profileUrl: payload.profileImageUrl,
           },
         })
       },

--- a/src/features/auth/types/auth.ts
+++ b/src/features/auth/types/auth.ts
@@ -7,8 +7,13 @@ export interface LoginPayload {
 
 export interface UserInfo {
   userId: string
+  nickname: string
+  profileUrl: string | null
+}
+
+export interface ChatUserInfo {
+  userId: string
   username: string
-  userProfileImageUrl: string | null
 }
 
 export interface LoginResponse extends UserInfo {

--- a/src/pages/home/ui/FirstSection.tsx
+++ b/src/pages/home/ui/FirstSection.tsx
@@ -61,7 +61,7 @@ const FirstSection = () => {
         </CtaContainer>
       ) : (
         <CarouselContainer>
-          <Title>{isLogin ? TITLE_TEXT.MEMBER(userInfo.username) : TITLE_TEXT.GUEST}</Title>
+          <Title>{isLogin ? TITLE_TEXT.MEMBER(userInfo.nickname) : TITLE_TEXT.GUEST}</Title>
           <HomeCarousel
             data={isLogin ? (MyCdData ?? RandomCdData) : RandomCdData}
             isLogin={isLogin}

--- a/src/pages/mypage/ui/main/components/MyCdList.tsx
+++ b/src/pages/mypage/ui/main/components/MyCdList.tsx
@@ -49,7 +49,7 @@ const MyCdList = () => {
               <Cd variant="responsive" stickers={item?.cdResponse?.cdItems} />
               {!item?.isPublic && <PrivateBadge>비공개</PrivateBadge>}
             </CdButton>
-            <CdNameInfo title={item?.playlistName || ''} creator={userInfo?.username || ''} />
+            <CdNameInfo title={item?.playlistName || ''} creator={userInfo?.nickname || ''} />
           </li>
         ))}
       </CdListWrap>

--- a/src/pages/mypage/ui/main/components/UserProfile.tsx
+++ b/src/pages/mypage/ui/main/components/UserProfile.tsx
@@ -26,15 +26,13 @@ const UserProfile = () => {
     file: File | null
     profileImage: string | null
   }>({
-    nickname: userInfo.username,
-    profileImage: userInfo?.userProfileImageUrl || null,
+    nickname: userInfo.nickname,
+    profileImage: userInfo?.profileUrl || null,
     file: null,
   })
 
   // 화면에 보여줄 프리뷰 URL
-  const [previewImage, setPreviewImage] = useState<ProfileUrl>(
-    userInfo?.userProfileImageUrl || null
-  )
+  const [previewImage, setPreviewImage] = useState<ProfileUrl>(userInfo?.profileUrl || null)
 
   // 프로필 편집 버튼 클릭
   const onProfileEditClick = () => {
@@ -67,11 +65,11 @@ const UserProfile = () => {
     setIsEditMode(false)
     setHasErrorMsg('')
     setUpdatedProfile({
-      nickname: userInfo.username,
-      profileImage: userInfo?.userProfileImageUrl || null,
+      nickname: userInfo.nickname,
+      profileImage: userInfo?.profileUrl || null,
       file: null,
     })
-    setPreviewImage(userInfo?.userProfileImageUrl || null)
+    setPreviewImage(userInfo?.profileUrl || null)
   }
 
   // 프로필 이미지 선택
@@ -86,10 +84,10 @@ const UserProfile = () => {
       }
       setUpdatedProfile((prev) => ({
         ...prev,
-        profileImage: userInfo?.userProfileImageUrl || null,
+        profileImage: userInfo?.profileUrl || null,
         file: null,
       }))
-      setPreviewImage(userInfo?.userProfileImageUrl || null)
+      setPreviewImage(userInfo?.profileUrl || null)
       return
     }
 
@@ -139,7 +137,7 @@ const UserProfile = () => {
         {hasErrorMsg && <FileErrMsg>{hasErrorMsg}</FileErrMsg>}
 
         {!isEditMode ? (
-          <ProfileName>{userInfo.username}</ProfileName>
+          <ProfileName>{userInfo.nickname}</ProfileName>
         ) : (
           <Input
             type="text"


### PR DESCRIPTION
<!-- ⚠️ PR 제목은 관련 이슈번호의 제목과 동일하게 설정해주세요! ⚠️ -->

## 🛰️ 관련 이슈

<!--
  - 하단의 issue_number를 관련 이슈 번호(들)로 설정해주세요.
  - 여러 개의 이슈가 연관되어 있을 경우 엔터로 구분해주세요.
-->

- close #192 

<br />

## ✨ 주요 변경 사항

<!--
  - ### 1️⃣, ### 2️⃣, ### 3️⃣, ### 4️⃣ 등으로 구분해주세요.
  - 스크린샷은 필요 시 주요 변경사항에 함께 첨부해주시면 좋습니다.
-->

- 2차 스프린트 배포에 반영 예정이었던 API 응답 규격이 운영 환경에 조기 반영됨에 따라, 프론트엔드 코드의 response key를 해당 규격에 맞춰 수정합니다.
- 서비스 정상화를 위해 긴급 배포를 진행하며 진행 중인 2차 스프린트 코드와 혼합되지 않게 develop에 반영 없이 바로 main에 merge할 예정입니다.
- 로그인, 프로필 수정 key name이 username → nickname, userProfileImageUrl → profileUrl로 변경되었습니다.
- 로그인 api의 response key가 nickname으로 변경되었는데 채팅 본인 확인은 기존 username 규격을 유지하고 있어, 타입 불일치 에러를 해소하기 위해 별도의 ChatUserInfoType을 생성하여 타입을 맞춰주었습니다.

<br />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 사용자 프로필 정보 저장 및 표시 방식이 재구성되었습니다.
  * 사용자 인증 및 프로필 관리 기능의 내부 데이터 구조가 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->