### PR TITLE
[fix] UI, 커스터마이징 및 기타 관련 QA 2차 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dnd-13th-8-frontend",
   "private": true,
-  "version": "1.1.1",
+  "version": "2.0.0",
   "type": "module",
   "engines": {
     "node": "22.12.0"

--- a/src/entities/playlist/model/useMyCd.ts
+++ b/src/entities/playlist/model/useMyCd.ts
@@ -56,7 +56,7 @@ export const useMyCdActions = (cdId: number, options?: { enabled?: boolean }) =>
       queryClient.invalidateQueries({ queryKey: ['playlistDetail', cdId] })
       queryClient.invalidateQueries({ queryKey: ['getTracklist', cdId] })
       queryClient.invalidateQueries({ queryKey: ['myCdList'] })
-      queryClient.invalidateQueries({ queryKey: ['feedCdList'] })
+      queryClient.invalidateQueries({ queryKey: ['feedCdInfiniteList'] })
     },
   })
 

--- a/src/entities/playlist/model/usePlaylists.ts
+++ b/src/entities/playlist/model/usePlaylists.ts
@@ -141,7 +141,7 @@ export const useFeedCdList = ({
   params: Omit<CdListParams, 'cursor'>
 }) => {
   return useInfiniteQuery({
-    queryKey: ['feedCdList', shareCode, feedView, params.sort],
+    queryKey: ['feedCdInfiniteList', shareCode, feedView, params.sort],
     queryFn: ({ pageParam }) => {
       const fetchParams = {
         ...params,

--- a/src/pages/admin/ui/AddTrackToBundle.tsx
+++ b/src/pages/admin/ui/AddTrackToBundle.tsx
@@ -19,8 +19,6 @@ const AddTrackToBundle = () => {
 
   const filteredBundleList = allBundleList?.filter((bundle) => bundle.timeSlot === currentTab)
 
-  console.log(filteredBundleList)
-
   const onClickTitle = (bundleId: number) => {
     setCurrentBundleId(bundleId)
     const bundle = allBundleList?.find((bundle) => bundle.bundleId === bundleId)

--- a/src/pages/admin/ui/AddTrackToBundle.tsx
+++ b/src/pages/admin/ui/AddTrackToBundle.tsx
@@ -19,6 +19,8 @@ const AddTrackToBundle = () => {
 
   const filteredBundleList = allBundleList?.filter((bundle) => bundle.timeSlot === currentTab)
 
+  console.log(filteredBundleList)
+
   const onClickTitle = (bundleId: number) => {
     setCurrentBundleId(bundleId)
     const bundle = allBundleList?.find((bundle) => bundle.bundleId === bundleId)
@@ -95,7 +97,7 @@ const AddTrackToBundle = () => {
                   $isActive={currentBundleId === bundle.bundleId}
                   onClick={() => onClickTitle(bundle.bundleId)}
                 >
-                  {`${bundle.bundleId}`.padStart(2, '0')} | {bundle.title}
+                  {`${bundle.bundleId}`.padStart(2, '0')} | {bundle.title.replaceAll('\n', '\\n')}
                 </Title>
                 <SvgButton
                   width={18}

--- a/src/pages/admin/ui/CreateBundle.tsx
+++ b/src/pages/admin/ui/CreateBundle.tsx
@@ -6,7 +6,6 @@ import { useToast } from '@/app/providers'
 import { TIME_SLOTS, useBundle } from '@/entities/bundle'
 import { flexColCenter, flexRowCenter } from '@/shared/styles/mixins'
 import type { TimeSlot } from '@/shared/types/common'
-import { Input } from '@/shared/ui'
 
 const CreateBundle = () => {
   const { toast } = useToast()
@@ -51,14 +50,17 @@ const CreateBundle = () => {
         ))}
       </TimeList>
       <TitleCtaBox>
-        <Input
-          type="text"
-          placeholder="모음집 제목을 입력해주세요"
+        <Textarea
+          rows={2}
+          cols={42}
           value={title}
+          placeholder="모음집 제목을 입력해주세요"
           onChange={(e) => setTitle(e.target.value)}
         />
         <SubmitButton disabled={!(timeSlot && title.trim().length)} onClick={onCreateBundleClick}>
-          타이틀 저장
+          제목
+          <br />
+          저장하기
         </SubmitButton>
       </TitleCtaBox>
     </>
@@ -115,4 +117,23 @@ const TitleCtaBox = styled.div`
   ${flexRowCenter}
   gap: 12px;
   width: 100%;
+`
+
+const Textarea = styled.textarea`
+  padding: 10px;
+  width: 100%;
+  border: 1px solid ${({ theme }) => theme.COLOR['gray-700']};
+  border-radius: 10px;
+  color: ${({ theme }) => theme.COLOR['gray-10']};
+  background-color: ${({ theme }) => theme.COLOR['gray-700']};
+  caret-color: ${({ theme }) => theme.COLOR['primary-normal']};
+  ${({ theme }) => theme.FONT['body2-normal']};
+
+  &::placeholder {
+    color: ${({ theme }) => theme.COLOR['gray-300']};
+  }
+
+  &:focus-within {
+    border: 1px solid ${({ theme }) => theme.COLOR['primary-normal']};
+  }
 `

--- a/src/pages/admin/ui/CreateBundle.tsx
+++ b/src/pages/admin/ui/CreateBundle.tsx
@@ -133,7 +133,7 @@ const Textarea = styled.textarea`
     color: ${({ theme }) => theme.COLOR['gray-300']};
   }
 
-  &:focus-within {
+  &:focus {
     border: 1px solid ${({ theme }) => theme.COLOR['primary-normal']};
   }
 `

--- a/src/pages/customize/step2/index.tsx
+++ b/src/pages/customize/step2/index.tsx
@@ -171,7 +171,7 @@ const CustomizeStep2 = ({
       {
         onSuccess: (response) => {
           setCurrentCdId?.(response?.playlistId ?? null)
-          queryClient.invalidateQueries({ queryKey: ['feedCdList'] })
+          queryClient.invalidateQueries({ queryKey: ['feedCdInfiniteList'] })
           setCurrentStep(3)
           removeTempData()
         },

--- a/src/pages/customize/step2/index.tsx
+++ b/src/pages/customize/step2/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useRef, useEffect } from 'react'
+import { useState, useMemo, useRef, useEffect, useLayoutEffect } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 
 import { useQueryClient, type DefaultError } from '@tanstack/react-query'
@@ -42,6 +42,7 @@ const CustomizeStep2 = ({
   const location = useLocation()
   const queryClient = useQueryClient()
 
+  const stickersRef = useRef<StickerInfoType[]>([])
   const fileInputRef = useRef<HTMLInputElement>(null)
   const cdContainerRef = useRef<HTMLCanvasElement>(null)
   const imageCache = useRef<{ [key: string]: HTMLImageElement | null }>({})
@@ -329,7 +330,7 @@ const CustomizeStep2 = ({
       const img = new Image()
       img.onload = () => {
         imageCache.current[src] = img
-        drawStickers()
+        drawStickers(stickersRef.current)
       }
       img.src = src
     }
@@ -496,7 +497,7 @@ const CustomizeStep2 = ({
 
     // resize 모드일 때는 Canvas를 즉시 업데이트
     if (resizeMode === 'resize') {
-      drawStickers()
+      drawStickers(updatedStickers)
     }
   }
 
@@ -595,12 +596,14 @@ const CustomizeStep2 = ({
   // ===============================
 
   // Canvas에 스티커 그리기
-  const drawStickers = (logicalSize = 280) => {
+  const drawStickers = (targetStickers?: StickerInfoType[], logicalSize = 280) => {
     const canvas = cdContainerRef.current
     if (!canvas) return
 
     const ctx = canvas.getContext('2d')
     if (!ctx) return
+
+    const stickersToDraw = targetStickers ?? stickersRef.current
 
     // Canvas 초기화
     ctx.clearRect(0, 0, logicalSize, logicalSize)
@@ -681,7 +684,7 @@ const CustomizeStep2 = ({
     ctx.clip()
 
     // 스티커들 그리기
-    stickers.forEach((sticker, index) => {
+    stickersToDraw.forEach((sticker, index) => {
       const cachedImg = imageCache.current[sticker.src]
 
       if (cachedImg && cachedImg.complete && cachedImg.naturalWidth > 0) {
@@ -817,82 +820,14 @@ const CustomizeStep2 = ({
     canvas.height = logicalSize * dpr
 
     // 좌표계 스케일링
+    ctx.setTransform(1, 0, 0, 1, 0, 0)
     ctx.scale(dpr, dpr)
 
     // 초기 그리기
-    drawStickers(logicalSize)
+    drawStickers(undefined, logicalSize)
 
     // 모바일 Safari 등에서 터치 스크롤 간섭 방지
     const stopDefault = (ev: TouchEvent) => ev.preventDefault()
-
-    // 수정 모드일 경우 스티커 데이터 화면에 렌더링
-    if (isEditMode && prevTracklist?.cdResponse?.cdItems.length) {
-      const prevStickers: StickerInfoType[] = prevTracklist.cdResponse.cdItems.map(
-        (prevSticker, index) => {
-          const scaleFactor = 280 / 285
-
-          // imageUrl이 DEFAULT면 테마에서 이미지 찾아오기
-          let src = prevSticker?.imageUrl ?? ''
-          if (src === 'DEFAULT') {
-            // 타입 오류 방지: item.theme을 StickerThemeType으로 명확히 변환
-            const theme = prevSticker.theme as StickerThemeType
-            const images = getCurrentThemeImages(theme) as Record<string, { default: string }>
-            const sortedKeys = Object.keys(images).sort((a, b) => {
-              const numA = parseInt(a.match(/(\d+)\.png$/)?.[1] ?? '0', 10)
-              const numB = parseInt(b.match(/(\d+)\.png$/)?.[1] ?? '0', 10)
-              return numA - numB
-            })
-
-            // propId에서 theme offset 빼고 index 계산
-            const themeOffset = getThemeOffset(theme)
-            const idx = prevSticker.propId - themeOffset - 1
-            src = images[sortedKeys[idx]]?.default ?? ''
-          }
-
-          return {
-            id: uuidv4(),
-            propId: prevSticker?.propId,
-            type: prevSticker?.theme as StickerThemeType,
-            src,
-            x: prevSticker.xCoordinate * scaleFactor,
-            y: prevSticker.yCoordinate * scaleFactor,
-            z: index + 1,
-            width: prevSticker.width * scaleFactor,
-            height: prevSticker.height * scaleFactor,
-            scale: prevSticker.scale,
-            rotation: prevSticker.angle,
-          }
-        }
-      )
-
-      // stickers 세팅 전에 이미지 미리 로드
-      let loadedCount = 0
-      prevStickers.forEach((sticker) => {
-        if (imageCache.current[sticker.src]) {
-          loadedCount++
-          if (loadedCount === prevStickers.length) {
-            setStickers(prevStickers)
-          }
-          return
-        }
-
-        const img = new Image()
-        img.onload = () => {
-          imageCache.current[sticker.src] = img
-          loadedCount++
-          if (loadedCount === prevStickers.length) {
-            setStickers(prevStickers)
-          }
-        }
-        img.onerror = () => {
-          loadedCount++
-          if (loadedCount === prevStickers.length) {
-            setStickers(prevStickers)
-          }
-        }
-        img.src = sticker.src
-      })
-    }
 
     return () => {
       canvas.removeEventListener('touchstart', stopDefault)
@@ -911,7 +846,7 @@ const CustomizeStep2 = ({
           imageCache.current[src] = img
           // 이미지 로딩 완료 후 Canvas 다시 그리기
           if (cdContainerRef.current) {
-            drawStickers()
+            drawStickers(stickersRef.current)
           }
         }
         img.src = src
@@ -928,7 +863,7 @@ const CustomizeStep2 = ({
           imageCache.current[src] = img
           // 이미지 로딩 완료 후 Canvas 다시 그리기
           if (cdContainerRef.current) {
-            drawStickers()
+            drawStickers(stickersRef.current)
           }
         }
         img.onerror = () => {
@@ -940,6 +875,79 @@ const CustomizeStep2 = ({
       }
     })
   }, [currentThemeId, stickerUrls])
+
+  // 수정 모드일 경우 스티커 데이터 화면에 렌더링
+  useEffect(() => {
+    if (!isEditMode) return
+    if (!prevTracklist?.cdResponse?.cdItems?.length) return
+
+    const prevStickers: StickerInfoType[] = prevTracklist.cdResponse.cdItems.map(
+      (prevSticker, index) => {
+        const scaleFactor = 280 / 285
+
+        // imageUrl이 DEFAULT면 테마에서 이미지 찾아오기
+        let src = prevSticker?.imageUrl ?? ''
+        if (src === 'DEFAULT') {
+          // 타입 오류 방지: item.theme을 StickerThemeType으로 명확히 변환
+          const theme = prevSticker.theme as StickerThemeType
+          const images = getCurrentThemeImages(theme) as Record<string, { default: string }>
+          const sortedKeys = Object.keys(images).sort((a, b) => {
+            const numA = parseInt(a.match(/(\d+)\.png$/)?.[1] ?? '0', 10)
+            const numB = parseInt(b.match(/(\d+)\.png$/)?.[1] ?? '0', 10)
+            return numA - numB
+          })
+
+          // propId에서 theme offset 빼고 index 계산
+          const themeOffset = getThemeOffset(theme)
+          const idx = prevSticker.propId - themeOffset - 1
+          src = images[sortedKeys[idx]]?.default ?? ''
+        }
+
+        return {
+          id: uuidv4(),
+          propId: prevSticker?.propId,
+          type: prevSticker?.theme as StickerThemeType,
+          src,
+          x: prevSticker.xCoordinate * scaleFactor,
+          y: prevSticker.yCoordinate * scaleFactor,
+          z: index + 1,
+          width: prevSticker.width * scaleFactor,
+          height: prevSticker.height * scaleFactor,
+          scale: prevSticker.scale,
+          rotation: prevSticker.angle,
+        }
+      }
+    )
+
+    // stickers 세팅 전에 이미지 미리 로드
+    let loadedCount = 0
+
+    prevStickers.forEach((sticker) => {
+      if (imageCache.current[sticker.src]) {
+        loadedCount++
+        if (loadedCount === prevStickers.length) {
+          setStickers(prevStickers)
+        }
+        return
+      }
+
+      const img = new Image()
+      img.onload = () => {
+        imageCache.current[sticker.src] = img
+        loadedCount++
+        if (loadedCount === prevStickers.length) {
+          setStickers(prevStickers)
+        }
+      }
+      img.onerror = () => {
+        loadedCount++
+        if (loadedCount === prevStickers.length) {
+          setStickers(prevStickers)
+        }
+      }
+      img.src = sticker.src
+    })
+  }, [isEditMode, prevTracklist])
 
   // 비회원이 로그인 후 돌아왔을 때 이전 데이터 복구 및 저장 실행
   useEffect(() => {
@@ -985,9 +993,15 @@ const CustomizeStep2 = ({
     }
   }, [isLogin])
 
-  // stickers가 변경될 때마다 다시 그리기
-  useEffect(() => {
-    drawStickers()
+  // 스티커 데이터 항상 최신화, 변경될 때마다 다시 그리기
+  useLayoutEffect(() => {
+    stickersRef.current = stickers
+
+    const frame = requestAnimationFrame(() => {
+      drawStickers(stickers)
+    })
+
+    return () => cancelAnimationFrame(frame)
   }, [stickers, selectedSticker])
 
   return (

--- a/src/pages/customize/step3/index.tsx
+++ b/src/pages/customize/step3/index.tsx
@@ -22,7 +22,6 @@ const CustomizeStep3 = ({ currentCdId }: { currentCdId: number | null }) => {
   const moveToTracklist = async () => {
     await queryClient.refetchQueries({ queryKey: ['playlistDetail', currentCdId] })
     await queryClient.refetchQueries({ queryKey: ['myCdList', 'RECENT'] })
-    await queryClient.refetchQueries({ queryKey: ['feedCdList'] })
     navigate(`/${userInfo.shareCode}/cds/${currentCdId}`)
   }
 

--- a/src/pages/feed/ui/FeedCarousel.tsx
+++ b/src/pages/feed/ui/FeedCarousel.tsx
@@ -130,6 +130,7 @@ const FeedCarousel = ({ type, pageType }: FeedCarouselProps) => {
               const nextId = getNextId(currentIdx, playlistData)
               navigate(nextId ? `../${nextId}` : '../../', { replace: true })
               queryClient.invalidateQueries({ queryKey: ['feedCdList'] })
+              queryClient.invalidateQueries({ queryKey: ['feedCdInfiniteList'] })
             },
           })
         },

--- a/src/pages/feed/ui/FeedProfile.tsx
+++ b/src/pages/feed/ui/FeedProfile.tsx
@@ -114,7 +114,7 @@ const FeedProfile = ({ userProfile, shareCode, isMyFeed, setModal }: FeedProfile
           </CtaButton>
         )}
         <ShareButton type="button" onClick={onShareButtonClick}>
-          <Share />
+          <Share width={20} height={20} />
         </ShareButton>
       </CtaContainer>
     </>

--- a/src/pages/home/ui/HomeCarousel.tsx
+++ b/src/pages/home/ui/HomeCarousel.tsx
@@ -168,7 +168,7 @@ const SlideOverlay = styled.div<{ $active: boolean; $hasPunchHole: boolean }>`
   bottom: 0;
   width: 100%;
   padding: 6px 16px 12px 16px;
-
+  border-radius: 0 0 20px 20px;
   background: rgba(124, 124, 124, 0.1);
   border-top: 0.5px solid rgba(255, 255, 255, 0.2);
   box-shadow:
@@ -180,29 +180,24 @@ const SlideOverlay = styled.div<{ $active: boolean; $hasPunchHole: boolean }>`
   ${({ $hasPunchHole }) =>
     $hasPunchHole &&
     css`
-      -webkit-mask-image: radial-gradient(
-        ellipse 25.5px 17px at 50.2% 0,
-        transparent 99%,
-        #000 100%
-      );
+      -webkit-mask-image: radial-gradient(circle 31px at 50% -20px, transparent 99%, #000 100%);
       -webkit-mask-repeat: no-repeat;
       -webkit-mask-size: 100% 100%;
 
-      mask-image: radial-gradient(ellipse 25.5px 17px at 50.2% 0, transparent 99%, #000 100%);
+      mask-image: radial-gradient(circle 31px at 50% -20px, transparent 99%, #000 100%);
       mask-repeat: no-repeat;
       mask-size: 100% 100%;
 
       &::before {
         content: '';
         position: absolute;
-        top: -0.5px;
-        left: 50.2%;
-        transform: translateX(-50%);
-        width: 50.5px;
-        height: 17px;
-        border: 0.5px solid rgba(255, 255, 255, 0.2);
-        border-top: 0;
-        border-radius: 0 0 25.5px 25.5px / 0 0 17px 17px;
+        left: 50%;
+        top: -20px;
+        transform: translate(-50%, -50%);
+        width: 62px;
+        height: 62px;
+        border-radius: 50%;
+        background: rgba(255, 255, 255, 0.15);
         pointer-events: none;
       }
     `}

--- a/src/pages/home/ui/HomeCarousel.tsx
+++ b/src/pages/home/ui/HomeCarousel.tsx
@@ -129,7 +129,7 @@ const Slide = styled.div<{ $active: boolean }>`
   ${({ $active }) =>
     $active &&
     css`
-      border: 0.8px solid transparent;
+      border: 0.5px solid transparent;
       border-radius: 24px;
       transform: scale(1);
       background:
@@ -139,7 +139,8 @@ const Slide = styled.div<{ $active: boolean }>`
             ${({ theme }) => theme.COLOR['gray-800']}
           )
           padding-box,
-        linear-gradient(to bottom right, rgba(230, 255, 248, 0.5), rgb(24, 25, 32, 0.8)) border-box;
+        linear-gradient(to top left, rgba(93, 100, 118, 0.1) 10%, rgba(93, 100, 118, 1) 100%)
+          border-box;
     `}
 `
 

--- a/src/pages/home/ui/SplitCard.tsx
+++ b/src/pages/home/ui/SplitCard.tsx
@@ -47,11 +47,11 @@ const CardButton = styled.button`
   border-radius: 14px;
   ${flexColCenter}
   gap: 16px;
-  border: 0.5px solid transparent;
+  border: 0.7px solid transparent;
   border-radius: 16px;
   background:
-    linear-gradient(144.41deg, #2a2f39, #191b22) padding-box,
-    linear-gradient(135deg, rgba(74, 77, 97, 0.8), #1f2027 70%) border-box;
+    linear-gradient(144.41deg, #2a2f39 0%, #191b22 100%) padding-box,
+    linear-gradient(to top left, rgba(93, 100, 118, 0) 10%, rgba(93, 100, 118, 1) 100%) border-box;
 `
 
 const CdContainer = styled.div`

--- a/src/shared/api/instance.ts
+++ b/src/shared/api/instance.ts
@@ -2,7 +2,7 @@ import axios, { AxiosError } from 'axios'
 import type { AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 
 import { useAuthStore } from '@/features/auth'
-import { useGlobalModalStore } from '@/shared/store/globalModalStore'
+// import { useGlobalModalStore } from '@/shared/store/globalModalStore'
 
 export const axiosInstance = axios.create({
   baseURL: import.meta.env.VITE_API_URL,
@@ -25,9 +25,6 @@ axiosInstance.interceptors.request.use(
   },
   (error) => Promise.reject(error)
 )
-
-// 에러 모달 호출
-const store = useGlobalModalStore
 
 // 응답 interceptor
 axiosInstance.interceptors.response.use(
@@ -77,16 +74,17 @@ axiosInstance.interceptors.response.use(
     }
 
     // QA용 에러 로그 모달
-    const msg = error.response?.data?.message ?? ''
-    if (import.meta.env.VITE_ENVIRONMENT_TYPE !== 'PROD') {
-      store.setState({
-        isOpen: true,
-        title: `[${status}] ${code}`,
-        description: msg,
-        ctaType: 'single',
-        confirmText: '확인',
-      })
-    }
+    // const store = useGlobalModalStore
+    // const msg = error.response?.data?.message ?? ''
+    // if (import.meta.env.VITE_ENVIRONMENT_TYPE !== 'PROD') {
+    //   store.setState({
+    //     isOpen: true,
+    //     title: `[${status}] ${code}`,
+    //     description: msg,
+    //     ctaType: 'single',
+    //     confirmText: '확인',
+    //   })
+    // }
 
     console.error('Axios Error: ', error.response ?? error)
     return Promise.reject(error)

--- a/src/widgets/playlist/PlaylistWithSong.tsx
+++ b/src/widgets/playlist/PlaylistWithSong.tsx
@@ -61,8 +61,8 @@ const Wrapper = styled.div`
   border: 0.5px solid transparent;
   border-radius: 14px;
   background:
-    linear-gradient(144.41deg, #2a2f39, #191b22) padding-box,
-    linear-gradient(135deg, rgba(74, 77, 97, 0.6), #202128) border-box;
+    linear-gradient(144.41deg, #2a2f39 0%, #191b22 100%) padding-box,
+    linear-gradient(to top left, rgba(55, 57, 71, 0) 0%, rgba(71, 73, 91, 1) 100%) border-box;
 `
 
 const InfoText = styled.div`


### PR DESCRIPTION
<!-- ⚠️ PR 제목은 관련 이슈번호의 제목과 동일하게 설정해주세요! ⚠️ -->

## 🛰️ 관련 이슈

<!--
  - 하단의 issue_number를 관련 이슈 번호(들)로 설정해주세요.
  - 여러 개의 이슈가 연관되어 있을 경우 엔터로 구분해주세요.
-->

- close #222

<br />

## ✨ 주요 변경 사항 / PR 포인트

<!--
  - ### 1️⃣, ### 2️⃣, ### 3️⃣, ### 4️⃣ 등으로 구분해주세요.
  - 스크린샷은 필요 시 주요 변경사항에 함께 첨부해주시면 좋습니다.
-->

### 1️⃣ 메인 페이지

- HomeCarousel 하단 overlay에 border-radius 적용
- HomeCarousel 펀칭 css값 수정
- 메인페이지 캐러셀 테두리, border 수정된 스타일에 맞게 수정

### 2️⃣ 피드 페이지

- 공유 버튼 이미지 사이즈 조정

### 3️⃣ 커스터마이징 페이지

- cd 수정 진입 시 canvas 이미지 렌더링 지연 현상 수정
- step3 feedList refetchQueries 제거

### 4️⃣ 어드민 페이지

- 모음집 제목 input → textarea 수정

### 5️⃣ 기타

- instance에 QA용 에러 로그 모달 주석 처리
- 중복되는 feedList 쿼리 키 분리

<br />

## 🚀 알게된 점

<!--
  - 코드를 작성 하면서 어떤 고민점이 있었는지, 또는 배우게된 것이 있다면 작성해주세요.
  - 작성하지 않아도 될 경우 이 항목을 '- 없음' 으로 작성해주세요.
-->

### cd 수정 시 스티커가 바로 렌더링되지 않고 클릭 등의 액션이 있어야 그려지는 현상 트러블슈팅

> **⚠️ 문제**

- 실제로는 스티커 state는 들어가 있으나 canvas에는 바로 안그려지고, 사용자가 canvas를 클릭하거나 액션을 주면 그려짐
- 데이터는 있지만 초기 진입 시 canvas redraw가 최신 데이터 기준으로 안정적으로 실행되지 않음

> **🔍 원인**

1️⃣ **canvas는 react가 자동으로 그려주지 않음**

- sticker state가 바뀌어도 canvas 안 픽셀은 자동 갱신되지 않으므로, drawStickers()를 직접 호출해야 함

2️⃣ **이미지 로딩 콜백(img.onload)이 과거 상태를 보고 다시 그릴 가능성이 있었음**

  ```typescript
  img.onload = () => {
    imageCache.current[src] = img
    drawStickers()
  }
  ```
- onload가 비동기 콜백이라 나중에 실행되기 때문에, 실행 시점에 예전 render의 값을 참조할 수 있음

따라서

1. 수정 모드에서 setStickers(prevStickers) 완료
2. 한 번은 잘 그려짐 _(간헐적으로 정상 동작했던 이유)_
3. 그런데 늦게 끝난 다른 이미지 preload onload가 실행됨
4. 그 콜백 안의 drawStickers()가 과거의 빈 stickers 기준으로 다시 그림
5. 결과적으로 canvas에는 배경만 남고 스티커가 사라짐
6. 사용자가 클릭하면 최신 state 기준으로 다시 그려져서 그때 보임

👉 canvas redraw가 비동기 이미지 로딩 타이밍과 엇갈리면서 오래된 state로 다시 그려졌기 때문

> 💡 **해결 방법**

1️⃣ useRef

```typescript
const stickersRef = useRef<StickerInfoType[]>([])
```

- 항상 최신 stickers를 참조할 수 있는 저장소 생성
- useRef는 렌더와 상관없이 값을 보존하고, 비동기 콜백에서도 접근 가능

2️⃣ useLayoutEffect

```typescript
useLayoutEffect(() => {
  stickersRef.current = stickers

  const frame = requestAnimationFrame(() => {
    drawStickers(stickers)
  })

  return () => cancelAnimationFrame(frame)
}, [stickers, selectedSticker])
```

- useLayoutEffect는 useEffect보다 더 이른 시점에 실행됨
- 브라우저 paint 전에 canvas draw 타이밍을 맞추기 좋음
- stickerRef.current = stickers와 실제 redraw를 같은 흐름 안에서 묶을 수 있음

👉 최신 데이터 반영 → 그 데이터로 draw 순서를 더 안정적으로 보장하기 위해 사용

3️⃣ 수정 사항 종합

1. draw 함수가 오래된 클로저 state에 덜 의존하도록 직접 넘긴 배열이 있으면 그걸 그리고, 없으면 stickersRef.current의 최신값을 그림
2. preload onload에서 오래된 render()값을 물지 않고, 이미지 로딩이 늦게 끝나더라도 그 시점의 최신 스티커 배열 기준으로 다시 그리게 함
3. stickers 변경 시점의 draw를 useLayoutEffect로 통합해 순서가 같은 흐름에서 보장되게 수정

👉 drawStickers가 항상 최신 stickers를 사용하도록 만들고, preload 콜백과 state 변경 redraw를 그 기준으로 통일

<br />

## 📖 참고 자료 (선택)

<!--
  - 작업하면서 참고했던 문서가 있다면 공유해주세요.
  - 작성하지 않아도 될 경우 이 항목을 '- 없음' 으로 작성해주세요.
-->

- [매일메일: useEffect와 useLayoutEffect](https://www.maeil-mail.kr/question/46)
- [React 공식 문서: useLayoutEffect](https://ko.react.dev/reference/react/useLayoutEffect)
- [React 공식 문서: useRef](https://ko.react.dev/reference/react/useRef)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 번들 제목 입력란을 다중행 텍스트 영역으로 변경하여 개선된 편집 환경 제공

* **버그 수정**
  * 피드 관련 캐시 무효화 개선으로 CD 삭제/공개 상태 변경 시 피드가 정확히 갱신되도록 수정
  * 스티커/캔버스 렌더링 및 저장 플로우 개선으로 맞춤화 화면에서 표시 안정성 향상
  * 번들 제목의 줄바꿈 문자를 이스케이프하여 표시되는 텍스트 일관성 개선
  * 공유 아이콘 크기 조정 및 표시 개선

* **스타일**
  * 카드·배너·오버레이 등 UI 요소의 그래디언트, 테두리 및 레이아웃 미세 조정

* **기타**
  * 패키지 버전이 2.0.0으로 업데이트됨
<!-- end of auto-generated comment: release notes by coderabbit.ai -->